### PR TITLE
Update README.md + outputs.tf.md (yc-> nb / ncp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,12 @@ module "kube" {
 
 ## Configure Terraform for Nebius Cloud
 
-- Install [YC CLI](https://nebius.atlassian.net/wiki/spaces/NTPT/pages/6979777/Nebius.ai+Sandbox+cloud)
+- Install [NCP CLI](https://nebius.ai/docs/cli/operations/install-cli)
+- Authenticate using [Service Account authorization key](https://nebius.ai/docs/cli/operations/authentication/service-account)
 - Add environment variables for terraform authentication in Nebuis Cloud
 
 ```
-export YC_TOKEN=$(yc iam create-token)
-export YC_CLOUD_ID=$(yc config get cloud-id)
-export YC_FOLDER_ID=$(yc config get folder-id)
+export NCP_TOKEN=$(ncp iam create-token)
 ```
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,11 +28,11 @@ output "external_cluster_cmd" {
   description = <<EOF
     Kubernetes cluster public IP address.
     Use the following command to download kube config and start working with Nebius Managed Kubernetes cluster:
-    `$ yc managed-kubernetes cluster get-credentials --id <cluster_id> --external`
+    `$ ncp managed-kubernetes cluster get-credentials --id <cluster_id> --external`
     This command will automatically add kube config for your user; after that, you will be able to test it with the
     `kubectl get cluster-info` command.
   EOF
-  value       = var.public_access ? "yc managed-kubernetes cluster get-credentials --id ${nebius_kubernetes_cluster.kube_cluster.id} --external" : null
+  value       = var.public_access ? "ncp managed-kubernetes cluster get-credentials --id ${nebius_kubernetes_cluster.kube_cluster.id} --external" : null
 }
 
 # private ip with kube config download command
@@ -40,8 +40,8 @@ output "internal_cluster_cmd" {
   description = <<EOF
     Kubernetes cluster private IP address.
     Use the following command to download kube config and start working with Nebius Managed Kubernetes cluster:
-    `$ yc managed-kubernetes cluster get-credentials --id <cluster_id> --internal`
+    `$ ncp managed-kubernetes cluster get-credentials --id <cluster_id> --internal`
     Note: Kubernetes internal cluster nodes are available from the virtual machines in the same VPC as cluster nodes.
   EOF
-  value       = var.public_access == false ? "yc managed-kubernetes cluster get-credentials --id ${nebius_kubernetes_cluster.kube_cluster.id} --internal" : null
+  value       = var.public_access == false ? "ncp managed-kubernetes cluster get-credentials --id ${nebius_kubernetes_cluster.kube_cluster.id} --internal" : null
 }


### PR DESCRIPTION
CLI naming issue in GitHub repository ([terraform-nb-kubernetes](https://github.com/nebius/terraform-nb-kubernetes?tab=readme-ov-file#configure-terraform-for-nebius-cloud)) included 'yc' instead of 'ncp'.

+NCP installation URL changed from confluence URL to public documentation.
+Authenticating with CLI using SA doc added as a link.